### PR TITLE
Check for user count

### DIFF
--- a/gems.locked
+++ b/gems.locked
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/onlyoffice-testing-robot/onlyoffice_documentserver_testing_framework
+  revision: b2508150111ba3848f1c281021b63fea565ce912
+  specs:
+    onlyoffice_documentserver_testing_framework (0.0.1)
+      onlyoffice_logger_helper (~> 1)
+      onlyoffice_webdriver_wrapper (~> 0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -38,13 +46,13 @@ GEM
     onlyoffice_s3_wrapper (0.1.2)
       aws-sdk-s3 (~> 1)
       onlyoffice_file_helper (~> 0.1)
-    onlyoffice_webdriver_wrapper (0.1.1)
+    onlyoffice_webdriver_wrapper (0.1.2)
       headless (~> 2)
       onlyoffice_file_helper (~> 0.1)
       onlyoffice_logger_helper (~> 1)
       onlyoffice_s3_wrapper (~> 0.1)
       page-object (~> 2)
-      selenium-webdriver (= 3.142.6)
+      selenium-webdriver (= 3.142.7)
       watir (~> 6)
     overcommit (0.52.1)
       childprocess (>= 0.6.3, < 4)
@@ -71,7 +79,7 @@ GEM
       rubocop (>= 0.71.0)
     ruby-progressbar (1.10.1)
     rubyzip (1.3.0)
-    selenium-webdriver (3.142.6)
+    selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     unicode-display_width (1.6.1)
@@ -84,7 +92,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  onlyoffice_webdriver_wrapper
+  onlyoffice_documentserver_testing_framework!
   overcommit
   rubocop
   rubocop-performance

--- a/gems.rb
+++ b/gems.rb
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'onlyoffice_webdriver_wrapper', git: 'https://github.com/onlyoffice-testing-robot/onlyoffice_webdriver_wrapper'
+gem 'onlyoffice_documentserver_testing_framework', git: 'https://github.com/onlyoffice-testing-robot/onlyoffice_documentserver_testing_framework'
 
 group :development do
   gem 'overcommit'

--- a/main.rb
+++ b/main.rb
@@ -1,16 +1,20 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
-require 'onlyoffice_webdriver_wrapper'
+require 'onlyoffice_documentserver_testing_framework'
 require_relative 'onlyoffice_webdriver_page_opener/methods'
 
 screenshot_timeout = ENV['SCREENSHOT_TIMEOUT'] || 60
 
-chrome = OnlyofficeWebdriverWrapper::WebDriver.new(:chrome)
-chrome.open(form_url)
+instance = OnlyofficeDocumentserverTestingFramework::TestInstanceDocs.new
+chrome = instance.webdriver
+chrome.open(from_url)
 loop do
   OnlyofficeLoggerHelper.log("Current url: #{chrome.get_url}")
   chrome.webdriver_screenshot
   puts(chrome.browser_logs)
   sleep(screenshot_timeout)
+  unless instance.spreadsheet_editor.top_toolbar.users.count > 1
+    chrome.webdriver_error("Only one user is connected to current document")
+  end
 end


### PR DESCRIPTION
If user not in co-edit mode - this user will not generate
adequate load data, so instance can be closed