### PR TITLE
`create_loader_and_run_tests` now can be run on any ip

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -90,8 +90,8 @@ desc 'Create one more loader and run tests'
 task :create_loader_and_run_tests, :container_count do |_t, args|
   check_variables
   args.with_defaults(container_count: 30)
+  args.with_defaults(loader_ip: create_new_loader_and_info)
   container_count = args[:container_count].to_i
-  loader_ip = create_new_loader_and_info
   run_command = 'docker run -itd '\
                 "-e URL='#{ENV['WEBDRIVER_PAGE_OPENER_DS_URL']}' "\
                 "-e S3_KEY='#{ENV['WEBDRIVER_PAGE_OPENER_S3_KEY']}' "\
@@ -99,7 +99,7 @@ task :create_loader_and_run_tests, :container_count do |_t, args|
                 "'#{ENV['WEBDRIVER_PAGE_OPENER_S3_PRIVATE_KEY']}' "\
                 'shockwavenn/onlyoffice-webdriver-page-opener;'
   container_count.times do |_|
-    `ssh -o StrictHostKeyChecking=no root@#{loader_ip} "#{run_command}"`
+    `ssh -o StrictHostKeyChecking=no root@#{args[:loader_ip]} "#{run_command}"`
     puts('Run one container')
     sleep(5) # Timeout between commands to not be banned by ssh
   end


### PR DESCRIPTION
Add param to this method to specify ip of server where to
add some loaders, by default it'll create new DO droplet, but
you can specify own by `loader_ip` param